### PR TITLE
Add dangerfile for Python projects

### DIFF
--- a/PythonDangerFile
+++ b/PythonDangerFile
@@ -1,0 +1,4 @@
+danger.import_dangerfile(github: "loadsmart/dangerfile", :path => "Dangerfile")
+
+# Don't let testing shortcuts get into master by accident
+fail("(i)pdb left in the code") if `find . -iname '*.py' | xargs grep -r "import [i]pdb"`.length > 1

--- a/PythonDangerFile
+++ b/PythonDangerFile
@@ -1,4 +1,4 @@
 danger.import_dangerfile(github: "loadsmart/dangerfile", :path => "Dangerfile")
 
-# Don't let testing shortcuts get into master by accident
+# Don't let (i)pdb get into master
 fail("(i)pdb left in the code") if `find . -iname '*.py' | xargs grep -r "import [i]pdb"`.length > 1


### PR DESCRIPTION
Add a specific `PythonDangerFile` to be used on Python projects. This follows the pattern used by mobile projects.