### PR TITLE
Fix the diff problem when a file has been moved

### DIFF
--- a/PythonDangerfile
+++ b/PythonDangerfile
@@ -4,7 +4,7 @@ danger.import_dangerfile(github: "loadsmart/dangerfile", :path => "Dangerfile")
 fail("(i)pdb left in the code") if `find . -iname '*.py' | xargs grep -r "import [i]pdb"`.length > 1
 
 # Check if diff contains 'import *'
-python_files = (git.modified_files + git.added_files).select { |file| file.end_with? ".py" }
+python_files = (git.modified_files + git.added_files).select { |file| file.end_with? ".py" }.reject { |file| file.include? "=>" }
 python_files.each { |file|
   diff = git.diff_for_file(file)
   if diff && diff.patch =~ /^\+[\t \w\.]*[\t ]+import[\t ]\*/i


### PR DESCRIPTION
@loop0 reported this bug: https://circleci.com/gh/loadsmart/alice/8157

When we move a file, the `git.modified_files` returns a `head/{shipments => timezones}/templatetags/time_utils.py`. The `diff.patch` doesn't understand it as a file and raises an exception.

With this PR, we avoid this kind of situation by filtering the files excluding `=>` strings.