### PR TITLE
Remove missing localizable strings from ios

### DIFF
--- a/iOSDangerfile
+++ b/iOSDangerfile
@@ -25,4 +25,4 @@ warn("View files were changed. Maybe you want to add a screenshot to your PR.") 
 # Plugins
 
 swiftlint.lint_files
-missed_localizable_strings.check_localizable_omissions
+


### PR DESCRIPTION
Removing missing localizable strings from iOS. LoadsmartSDK doesn't need it. Another PR will add it back to liveloads-ios 