### PR TITLE
mobile: remove check from PRs coming from develop

### DIFF
--- a/MobileDangerfile
+++ b/MobileDangerfile
@@ -1,10 +1,5 @@
 danger.import_dangerfile(github: "loadsmart/dangerfile", :path => "Dangerfile")
 
-# Only accept PRs to the develop branch
-if github.branch_for_base != "develop" && !github.pr_title.include?("hotfix")
-  fail "Please re-submit this PR to the develop branch"
-end
-
 if @LS_DANGER_REPORT_CIRCLE_CI_ARTIFACTS
   username = ENV['CIRCLE_PROJECT_USERNAME']
   project_name = ENV['CIRCLE_PROJECT_REPONAME']


### PR DESCRIPTION
We're trying a new approach with feature and partial branches.

The flow from now on would be master -> develop -> feature -> partial, with people reviewing PR diffs of `feature` and `partial`.