### PR TITLE
add service maturity level attributes to catalog file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,6 +5,7 @@ metadata:
   description: Loadsmart's global Dangerfile
   annotations:
     github.com/project-slug: loadsmart/dangerfile
+    opslevel.com/tier: tier_3
   tags:
     - ruby
 spec:


### PR DESCRIPTION
### Context
The purpose of this pull request is to ensure the repository has basic attributes for service maturity level in backstage catalog, in line with the service maturity level initiative led by the Developer Productivity Squad.
