### PR TITLE
chore: include roadrunners as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@loadsmart/mobile
+*	@loadsmart/roadrunners @loadsmart/mobile

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,4 +11,4 @@ metadata:
 spec:
   type: other
   lifecycle: production
-  owner: mobile
+  owner: roadrunners


### PR DESCRIPTION
Setting roadrunners as CODEOWNER